### PR TITLE
Explicitely request fields when getting user info from FB

### DIFF
--- a/lib/omniauth/strategies/facebook.rb
+++ b/lib/omniauth/strategies/facebook.rb
@@ -6,6 +6,7 @@ module OmniAuth
   module Strategies
     class Facebook < OmniAuth::Strategies::OAuth2
       DEFAULT_SCOPE = 'email,offline_access'
+      DEFAULT_FIELDS = 'id,name,email,first_name,last_name'.freeze
 
       option :client_options, {
         :site => 'https://graph.facebook.com',
@@ -56,7 +57,7 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('/me').parsed
+        @raw_info ||= access_token.get("/me?fields=#{DEFAULT_FIELDS}").parsed
       end
 
       def build_access_token


### PR DESCRIPTION
We use a really old version of `omniauth-facebook` (the last one that is compatible with our R2 stack).

Because of a recent API deprecation, we didn't receive the user's email anymore (we now have to ask for it explicitly when requesting the user info from Facebook).

This PR addresses that.